### PR TITLE
Initial schedule

### DIFF
--- a/definitions.php
+++ b/definitions.php
@@ -146,6 +146,7 @@
 
 	function print_enssys_info()
 	{
+		print "<p><b><a href=\"programme.php\">New: The schedule for ENSsys@SenSys is up!</a></b></p>";
 		print "<p>Complementing the topics of SenSys 2021 and ASPLOS 2022, this workshop will bring researchers together to explore the challenges, issues, and opportunities in the research, design, and engineering of energy-harvesting, energy-neutral, and intermittent sensing systems.</p>";
 		print "<p>New this year, ENSsys will run twice, first as a part of SenSys 2021 and then <span style=\"color:grey\">(tentatively)</span> as a part of ASPLOS 2022. Our goal is to leverage the success of ENSsys to both continue to support our home in the wireless sensor networking community and to grow interest and excitement for energy neutral, energy harvesting, and intermittent systems in the computer architecture and systems communities. For ENSsys@SenSys, we invite 1-2 page demo abtracts and short 2-3 page short papers. The short papers, which may be early ideas, will receive thoughtful feedback from TPC members and seed breakout discussions in the afternoon of ENSsys@SenSys. Short papers that grow to full paper submissions in time for the second iteration of ENSsys@ASPLOS will receive special consideration and the same set of reviewers <span style=\"color:grey\">(where possible)</span>. Accepted demos will also be invited to repeat their demo again at ASPLOS.</p>";
 	}

--- a/programme.php
+++ b/programme.php
@@ -2,6 +2,131 @@
 		
 <h1>Technical Programme</h1>
 
-<p>Further information will appear here after the notification deadline</p>
+ENSsys will be run in a hybrid format this year.
+For this reason, we are operating on a slightly compressed schedule to maximize accessibility across time zones.
+
+<h2>Overview</h2>
+
+<p>The ENSsys schedule is designed to co-ordinate where possible with the
+<a href="https://sensys.acm.org/2021/program/">full SenSys schedule.</a></p>
+
+<!-- I would just like to say that daylight savings is the worst and needs to *go away* -->
+<table style="border-spacing: 10px">
+  <tr>
+    <th><!-- What !--></th>
+    <th><b><a href="https://en.wikipedia.org/wiki/Western_European_Time">WET</a> (Coimbra local)</b></th>
+    <td><a href="https://en.wikipedia.org/wiki/Eastern_Time_Zone">EST</a> (US/Eastern)</td>
+    <td><a href="https://en.wikipedia.org/wiki/Pacific_Time_Zone">PST</a> (US/Pacific)</td>
+    <td><a href="https://en.wikipedia.org/wiki/Indian_Standard_Time">IST</a> (Indian Standard)</td>
+    <td><a href="https://en.wikipedia.org/wiki/Time_in_China">CST</a> (China Standard)</td>
+  </tr>
+  <tr>
+    <td><!-- What !--></td>
+    <td><b>UTC+0</b></td>
+    <td>UTC-5</td>
+    <td>UTC-8</td>
+    <td>UTC+5:30</td>
+    <td>UTC+8</td>
+  </tr>
+  <tr>
+    <!-- padding row -->
+  </tr>
+  <tr>
+    <td>Welcome &amp; Opening Remarks</td>
+    <td>15:00-15:10</td>
+    <td>10:00-10:10</td>
+    <td>7:00-7:10</td>
+    <td>20:30-20:40</td>
+    <td>23:00-23:10</td>
+  </tr>
+  <tr>
+    <td>Spotlight Demo Sessions</td>
+    <td>15:10-16:10</td>
+    <td>10:10-11:10</td>
+    <td>7:10-8:10</td>
+    <td>20:40-21:40</td>
+    <td>23:10-00:10</td>
+  </tr>
+  <tr>
+    <td>Energy Harvesting Village &amp; Coffee Break</td>
+    <td>16:10-17:00</td>
+    <td>11:10-12:00</td>
+    <td>8:10-9:00</td>
+    <td>21:40-22:30</td>
+    <td>00:10-1:00</td>
+  </tr>
+  <tr>
+    <td>Workshop Sessions</td>
+    <td>17:00-18:30</td>
+    <td>12:00-13:30</td>
+    <td>9:00-10:30</td>
+    <td>22:30-00:00</td>
+    <td>1:00-2:30</td>
+  </tr>
+</table>
+
+<h2>Full Programme</h2>
+
+<h3>Demo Session &amp; Energy Harvesting Village</h3>
+<p>This session will spotlight and showcase real-world, working energy-harvesting and energy-neutral systems.
+To accommodate the hybrid nature of the event, we will kick off the session with
+a series of spotlights of each of the demos. After the spotlights, attendees
+can visit demos for more details via physical attendance at demo setups or
+checking in to demo-specific video conferencing rooms.</p>
+<p>The open demo session is timed to overlap with the coffee break for all
+workshops, so demo presenters are encouraged to try to hang around near their
+demos such that attendees of other SenSys workshops may have an opportunity to
+visit your demo.</p>
+
+<table style="border-spacing: 5px">
+  <tr>
+    <td>WET (Coimbra local)</td>
+  </tr>
+  <tr>
+    <td>15:10-15:20</td>
+    <td>Demo: Energy-Aware Battery-Less Bluetooth Low Energy Device Prototype Powered By Ambient Light</td>
+  </tr>
+  <tr>
+    <td>15:20-15:30</td>
+    <td>Demo: Demonstration of an Energy-Aware Task Scheduler for Battery-Less IoT Devices</td>
+  </tr>
+  <tr>
+    <td>15:30-15:40</td>
+    <td>Demo: RF Power Transmission: Energy Harvesting for Self-Sustaining Miniaturized Sensor Nodes</td>
+  </tr>
+  <tr>
+    <td>15:40-15:50</td>
+    <td>Demo: A Battery-Free Long-Range Wireless Smart Camera for Face Recognition</td>
+  </tr>
+  <tr>
+    <td>15:50-16:00</td>
+    <td>Demo: Powering an E-Ink Display from Soil Bacteria</td>
+  </tr>
+  <tr>
+    <td>16:00-16:10</td>
+    <td>Demo: A Simulation and Prototyping Toolkit for Airflow Energy Harvesting in Vehicles</td>
+  </tr>
+  <tr>
+    <td>16:10-17:00</td>
+    <td>Open Village &amp; Coffee Break</td>
+  </tr>
+</table>
+
+<h3>Workshop Sessions</h3>
+<p>For paper authors, ENSsys will adopt a discussion-oriented workshop format. Paper authors
+will give a short overview of their ideas and prompts for discussion.</p>
+<p>Given the challenges of hybrid-based discussions, the tentative plan is to
+have two workshop breakouts, one for online presenters and attendees and one
+for in-person attendees. We will update this section with a schedule and more
+details once registration numbers are available and we have a better sense of
+how many remote versus in-person attendees we will have.</p>
+
+<ul>
+  <li>Autonomous Energy Status Sharing and Synchronization for Batteryless Sensor Networks</li>
+  <li>Persistent Timekeeping Using Harvested Power Measurements</li>
+  <li>Joint Energy Management for Distributed Energy Harvesting Systems</li>
+  <li>RESERVE: Remote Attestation of Intermittent IoT devices</li>
+  <li>Designing a General Purpose Development Platform for Energy-harvesting Applications</li>
+</ul>
 
 <br><br>


### PR DESCRIPTION
I tried to coordinate as best I could with the general SenSys schedule ( https://sensys.acm.org/2021/program/ ). Given what we discussed with demo spotlights + overlapping the open demo session with the coffee breaks of other workshops, I think that starting ENSsys an hour later makes the most sense [with apologies to our online folks in China/Australia :/ ]. I tried to lightly group similar demos, but they're reasonably mixed. I gave a quick overview of the plan for the second half, but figure we'll have to wait for registration numbers to get a final schedule there.

Rendered: 
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/339422/138743791-064260a0-8787-4fee-b1d0-7438544d111b.png">
